### PR TITLE
Revert "Changing update.sh to support AL2022"

### DIFF
--- a/update-script/update.sh
+++ b/update-script/update.sh
@@ -47,9 +47,6 @@ build_branch_name() {
     arch="${2:?}"
 
     case "$version" in
-        20??)
-            printf al%s "$version"
-            ;;
         201?.??)
             printf %s "$version"
             ;;
@@ -144,7 +141,7 @@ for arg in "$@"; do
     rpm --root "$image_workdir" --rebuilddb
 
     # Get system-release version
-    [[ $(rpm --root "$image_workdir" -q system-release --qf '%{version}') =~ (^2018.03$|^2$|^20[0-9]{2}) ]] && version="${BASH_REMATCH[1]}" || exit 1
+    version=$(rpm --root "$image_workdir" -q system-release --qf '%{version}')
     # Get architecture of image
     arch=$(rpm --root "$image_workdir" -q glibc --qf '%{arch}')
     branch_name=$(build_branch_name "$version" "$arch")
@@ -224,12 +221,12 @@ git clone https://github.com/docker-library/official-images.git
 cd official-images
 
 # If we didn't process a version locally, get the current date-stamped image tag
-for version in 2 2018.03 2022; do
+for version in 2 2018.03; do
     [[ -z ${FULL_VERSIONS[$version]:-} ]] && FULL_VERSIONS[$version]=$(awk -v v=$version, '$3 == v {print $2}' library/amazonlinux | tr -d ,)
 done
 
 # Get commit hashes for all the branches
-for branch in master {amzn2,amzn2-arm64,2018.03,al2022,al2022-arm64}{,-with-sources}; do
+for branch in master {amzn2,amzn2-arm64,2018.03}{,-with-sources}; do
     # First try to get the local commit; if it's not local, we're not pushing
     # it, so get the remote commit for this branch.
     COMMIT_FOR_BRANCH[$branch]=$(
@@ -279,20 +276,6 @@ Tags: ${FULL_VERSIONS[2018.03]}-with-sources, 2018.03-with-sources, 1-with-sourc
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: ${COMMIT_FOR_BRANCH[2018.03-with-sources]}
-
-Tags: ${FULL_VERSIONS[2022]}, 2022
-Architectures: amd64, arm64v8
-amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: ${COMMIT_FOR_BRANCH[al2022]}
-arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: ${COMMIT_FOR_BRANCH[al2022-arm64]}
-
-Tags: ${FULL_VERSIONS[2022]}-with-sources, 2022-with-sources
-Architectures: amd64, arm64v8
-amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: ${COMMIT_FOR_BRANCH[al2022-with-sources]}
-arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: ${COMMIT_FOR_BRANCH[al2022-arm64-with-sources]}
 EOF
 git commit -m "Update Amazon Linux images" library/amazonlinux
 git --no-pager show


### PR DESCRIPTION
Reverts amazonlinux/container-images#58

This is being done since we haven't yet done an official AL2022 release, which gives us no commit hashes to add to the library file. Will be added back for the 2022 Dockerhub release.