### PR TITLE
Renamed images directory to container-images

### DIFF
--- a/update-script/update.sh
+++ b/update-script/update.sh
@@ -308,4 +308,5 @@ EOF
 git commit -m "Update Amazon Linux images" library/amazonlinux
 git --no-pager show
 
+mv $OUTDIR/images $OUTDIR/container-images
 echo_green "Finished repositories in $OUTDIR"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the final images directory to be **container-images** instead of **images** this helps clear up confusion when we are running our MCM's. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
